### PR TITLE
Support for additional robot types through the introduction of robot composition and related documentation updates

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,7 +93,7 @@ html_css_files = [
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "numpy": ("https://numpy.org/doc/stable", None),
-    "torch": ('https://pytorch.org/docs/master/', None),
+    "torch": ('https://pytorch.org/docs/main/', None),
     "zonopy": ('https://roahmlab.github.io/zonopy/latest/', None),
     "trimesh": ('https://trimesh.org/', None),
 }

--- a/docs/source/robots.rst
+++ b/docs/source/robots.rst
@@ -6,6 +6,21 @@ Robots Module
 .. currentmodule:: zonopyrobots
 
 This module contains classes which specify robot parameters.
+This module also contains quick access to provided URDF's (currently just the Kinova Gen3).
+
+Included Robot URDFS
+--------------------
+Paths to the URDF's are stored in ``zonopyrobots.robots.files``.
+URDF's can also be opened with urchin through using ``zonopyrobots.robots.urdfs``.
+URDF's opened in this way are only loaded at first access, and all available robots mirror the URDF's in ``zonopyrobots.robots.files``.
+
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :recursive:
+
+    robots.files
+    robots.urdfs
 
 Arm Robots
 ----------

--- a/docs/source/robots.rst
+++ b/docs/source/robots.rst
@@ -9,6 +9,8 @@ This module contains classes which specify robot parameters.
 
 Arm Robots
 ----------
+ZonoArmRobot is also aliased as ArmZonoRobot.
+
 .. autosummary::
     :toctree: generated
     :nosignatures:
@@ -17,3 +19,23 @@ Arm Robots
     ZonoArmRobot
     robots.armrobot.ZonoArmRobotLink
     robots.armrobot.ZonoArmRobotJoint
+
+SE2 and SE3 Robots
+------------------
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :recursive:
+
+    SE2ZonoRobot
+    SE3ZonoRobot
+
+Composable Robots
+-----------------
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+    :recursive:
+
+    ComposedZonoRobot
+

--- a/docs/source/robots.rst
+++ b/docs/source/robots.rst
@@ -39,3 +39,21 @@ Composable Robots
 
     ComposedZonoRobot
 
+Robot Base Class
+----------------
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    BaseZonoRobot
+
+Robot Utility Functions
+-----------------------
+.. currentmodule:: zonopyrobots.robots
+.. autosummary::
+    :toctree: generated
+    :nosignatures:
+
+    make_urdf_fixed
+    make_baselink_urdf
+

--- a/zonopyrobots/__init__.py
+++ b/zonopyrobots/__init__.py
@@ -1,3 +1,4 @@
+import zonopyrobots.robots as robots
 from zonopyrobots.robots import *
 from zonopyrobots.util import *
 

--- a/zonopyrobots/__init__.py
+++ b/zonopyrobots/__init__.py
@@ -13,4 +13,5 @@ from zonopyrobots.joint_reachable_set.jrs_trig.process_jrs_trig import *
 import zonopy.internal as internal
 
 
+from .properties import __version__, __logo__
 

--- a/zonopyrobots/dynamics/RNEA.py
+++ b/zonopyrobots/dynamics/RNEA.py
@@ -50,8 +50,8 @@ def pzrnea(rotatotopes: Union[Dict[str, Union[MPZType, BMPZType]], List[Union[MP
             The robot to use for the RNEA
         zono_order (int, optional): 
             The order of the zonotopes to use. Lower is faster but less accurate. Defaults to 40.
-        gravity (Union[torch.Tensor, np.ndarray], optional):
-            The gravity vector to use. Defaults to [0, 0, -9.81].
+        gravity (Union[torch.Tensor, np.ndarray, None], optional):
+            The gravity vector to use. Defaults to [0, 0, -9.81]. If None, no gravity is used.
         link_mass_override (Dict[str, Any], optional):
             Dictionary of link masses to override the URDF values. Defaults to None.
         link_center_mass_override (Dict[str, Any], optional): [description].

--- a/zonopyrobots/kinematics/FK.py
+++ b/zonopyrobots/kinematics/FK.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     FKOriginType = Union[str, FKOrigin, Tuple[PZType, MPZType], Tuple[BPZType, BMPZType], Tuple[torch.Tensor, torch.Tensor]]
 
 
-# This is based on the Urchin's FK source
+# This is based on the Urchin's FK source. This version is only written to handle continuous and revolute joints.
 def forward_kinematics(
         rotatotopes: Union[Dict[str, Union[MPZType, BMPZType]],
                            List[Union[MPZType, BMPZType]]],

--- a/zonopyrobots/kinematics/FK.py
+++ b/zonopyrobots/kinematics/FK.py
@@ -5,9 +5,19 @@ from typing import TYPE_CHECKING
 from zonopy import polyZonotope, matPolyZonotope, batchPolyZonotope, batchMatPolyZonotope
 from collections import OrderedDict
 from zonopyrobots.robots import ZonoArmRobot
+from enum import Enum
 import numpy as np
 import torch
 import functools
+
+from zonopyrobots.util.make_config_dict import make_cfg_dict
+
+
+class FKOrigin(str, Enum):
+    """The origin of the forward kinematics."""
+    BASE = "base"
+    WORLD = "world"
+
 
 if TYPE_CHECKING:
     from typing import Union, Dict, List, Tuple
@@ -17,8 +27,8 @@ if TYPE_CHECKING:
     from zonopy import batchPolyZonotope as BPZType
     from zonopy import batchMatPolyZonotope as BMPZType
     from urchin import URDF
+    FKOriginType = Union[str, FKOrigin, Tuple[PZType, MPZType], Tuple[BPZType, BMPZType], Tuple[torch.Tensor, torch.Tensor]]
 
-from zonopyrobots.util.make_config_dict import make_cfg_dict
 
 # This is based on the Urchin's FK source
 def forward_kinematics(
@@ -27,6 +37,7 @@ def forward_kinematics(
         robot: ZonoArmRobot,
         zono_order: int = 20,
         links: List[str] = None,
+        origin: FKOriginType = FKOrigin.BASE,
         ) -> OrderedDictType[str, Union[Tuple[PZType, MPZType],
                                         Tuple[BPZType, BMPZType]]]:
     """Computes the forward kinematics of a robot.
@@ -36,49 +47,65 @@ def forward_kinematics(
         robot (ZonoArmRobot): The robot.
         zono_order (int, optional): The zonotope order. Defaults to 20.
         links (List[str], optional): The links. Defaults to None.
+        origin (FKOriginType, optional): The origin of the forward kinematics. Defaults to FKOrigin.BASE. Can be a string, FKOrigin, or a tuple of position and rotation.
 
     Returns:
         OrderedDictType[str, Union[Tuple[PZType, MPZType], Tuple[BPZType, BMPZType]]]: The forward kinematics.
+            Each value is the position and rotation of the link in the base frame.
     """
-    if robot.is_single_chain and len(rotatotopes) == robot.dof:
-        return forward_kinematics_single(rotatotopes, robot, zono_order, links)
+    if robot.is_single_chain and isinstance(rotatotopes, list) and len(rotatotopes) == robot.dof:
+        return forward_kinematics_single(rotatotopes, robot, zono_order, links, origin)
     # Create the rotato config dictionary
     cfg_map = make_cfg_dict(rotatotopes, robot.urdf)
     urdf = robot.urdf
 
     # Get our output link set, assume it's all links if unspecified
     if links is not None:
-        link_set = set()
-        for lnk in links:
-            link_set.add(urdf._link_map[lnk])
+        ext_link_set, link_set = __get_ext_link_set(urdf, links)
     else:
         link_set = __all_links_as_set(urdf)
+        ext_link_set = set()
     
     # Setup initial condition
     bpz_mask = np.array([isinstance(rotato, batchMatPolyZonotope) for rotato in rotatotopes])
+    batch_shape = None
     if np.any(bpz_mask):
         for idx, tf in enumerate(bpz_mask):
             if tf:
                 batch_shape = rotatotopes[idx].batch_shape
                 break
-        link_rot = [batchMatPolyZonotope.eye(batch_shape, 3, dtype=robot.dtype, device=robot.device)]
-        link_pos = [batchPolyZonotope.zeros(batch_shape, 3, dtype=robot.dtype, device=robot.device)]
+        base_pos = batchPolyZonotope.zeros(batch_shape, 3, dtype=robot.dtype, device=robot.device)
+        base_rot = batchMatPolyZonotope.eye(batch_shape, 3, dtype=robot.dtype, device=robot.device)
     else:
-        batch_shape = None
+        base_pos = polyZonotope.zeros(3, dtype=robot.dtype, device=robot.device)
+        base_rot = matPolyZonotope.eye(3, dtype=robot.dtype, device=robot.device)
 
     # Compute forward kinematics in reverse topological order, base to end
     fk = OrderedDict()
-    for lnk in urdf._reverse_topo:
-        if lnk not in link_set:
+
+    # Add the base link
+    topo_itr = iter(urdf._reverse_topo)
+    base_link = next(topo_itr)
+    if origin == FKOrigin.BASE:
+        fk[base_link] = (base_pos, base_rot)
+    elif origin == FKOrigin.WORLD:
+        pos = robot.origin_rot@base_pos + robot.origin_pos
+        rot = robot.origin_rot@base_rot
+        fk[base_link] = (pos, rot)
+    else:
+        origin_pos, origin_rot = origin
+        pos = origin_rot@base_pos + origin_pos
+        rot = origin_rot@base_rot
+        fk[base_link] =(pos, rot)
+
+    # do the rest
+    for lnk in topo_itr:
+        if lnk in ext_link_set:
             continue
         # Get the path back to the base and build with that
         path = urdf._paths_to_base[lnk]
-        if batch_shape is not None:
-            pos = batchPolyZonotope.zeros(batch_shape, 3, dtype=robot.dtype, device=robot.device)
-            rot = batchMatPolyZonotope.eye(batch_shape, 3, dtype=robot.dtype, device=robot.device)
-        else:
-            pos = polyZonotope.zeros(3, dtype=robot.dtype, device=robot.device)
-            rot = matPolyZonotope.eye(3, dtype=robot.dtype, device=robot.device)
+        pos = base_pos
+        rot = base_rot
         for i in range(len(path) - 1):
             child = path[i]
             parent = path[i + 1]
@@ -109,15 +136,17 @@ def forward_kinematics(
             rot = joint_rot@rot
 
             # Check existing FK to see if we can exit early
-            if parent.name in fk:
-                parent_pos, parent_rot = fk[parent.name]
+            if parent in fk:
+                parent_pos, parent_rot = fk[parent]
                 pos = parent_rot@pos + parent_pos
                 rot = parent_rot@rot
                 break
 
         # Save the values & reduce
-        fk[lnk.name] = (pos.reduce_indep(zono_order), rot.reduce_indep(zono_order))
+        fk[lnk] = (pos.reduce_indep(zono_order), rot.reduce_indep(zono_order))
 
+    # get the appropriate subset for the ordered dict
+    fk = OrderedDict((lnk.name, fk[lnk]) for lnk in fk if lnk in link_set)
     return fk
 
 def forward_kinematics_single(
@@ -125,15 +154,14 @@ def forward_kinematics_single(
         robot: ZonoArmRobot,
         zono_order: int = 20,
         links: List[str] = None,
+        origin: FKOriginType = FKOrigin.BASE,
         ) -> OrderedDictType[str, Union[Tuple[PZType, MPZType],
                                         Tuple[BPZType, BMPZType]]]:
     urdf = robot.urdf
 
     # Get our output link set, assume it's all links if unspecified
     if links is not None:
-        link_set = set()
-        for lnk in links:
-            link_set.add(urdf._link_map[lnk])
+        link_set = __make_link_set(urdf, links)
     else:
         link_set = __all_links_as_set(urdf)
 
@@ -160,6 +188,19 @@ def forward_kinematics_single(
     else:
         link_rot = [matPolyZonotope.eye(3, dtype=robot.dtype, device=robot.device)]
         link_pos = [polyZonotope.zeros(3, dtype=robot.dtype, device=robot.device)]
+    
+    # Consider origin option
+    if origin == FKOrigin.BASE:
+        pass
+    elif origin == FKOrigin.WORLD:
+        link_pos[0] = robot.origin_rot@link_pos[0] + robot.origin_pos
+        link_rot[0] = robot.origin_rot@link_rot[0]
+    else:
+        origin_pos, origin_rot = origin
+        link_pos[0] = origin_rot@link_pos[0] + origin_pos
+        link_rot[0] = origin_rot@link_rot[0]
+    
+    # Create the initial link set
     link_rot.extend(all_rot)
     link_pos.extend(all_pos)
     
@@ -178,3 +219,30 @@ def forward_kinematics_single(
 @functools.lru_cache
 def __all_links_as_set(robot: URDF) -> set:
     return set(robot.links)
+
+
+@functools.lru_cache
+def __make_link_set(robot: URDF, incl_link_names: List[str]) -> set:
+    if incl_link_names is None:
+        return __all_links_as_set(robot)
+    
+    incl_links = set()
+    for lnk in incl_link_names:
+        incl_links.add(robot._link_map[lnk])
+    return incl_links
+
+
+@functools.lru_cache
+def __get_ext_link_set(robot: URDF, incl_link_names: List[str]) -> Tuple[set, set]:
+    import networkx as nx
+    incl_links = __make_link_set(robot, incl_link_names)
+    all_links = __all_links_as_set(robot)
+
+    if incl_link_names is None:
+        return set(), all_links
+    
+    all_int_nodes = set()
+    for target in incl_links:
+      for path in nx.all_simple_paths(robot._G, source=target, target=robot.base_link):
+        all_int_nodes.update(path)
+    return all_links - all_int_nodes, incl_links

--- a/zonopyrobots/properties.py
+++ b/zonopyrobots/properties.py
@@ -11,7 +11,7 @@ A collection of internal properties for zonopyrobots.
     A fun little logo for zonopyrobots.
 
 """
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 __logo__ = """
 *** ZONO-PY ROBOTS ***
   _____         _____

--- a/zonopyrobots/robots/__init__.py
+++ b/zonopyrobots/robots/__init__.py
@@ -6,6 +6,8 @@ from .composablerobot import ComposedZonoRobot
 
 from .utils import make_urdf_fixed, make_baselink_urdf
 
+from .assets import files, urdfs
+
 __all__ = [
     "BaseZonoRobot",
     "ZonoArmRobot",

--- a/zonopyrobots/robots/__init__.py
+++ b/zonopyrobots/robots/__init__.py
@@ -1,1 +1,5 @@
-from .armrobot import ZonoArmRobot
+from .baserobot import BaseZonoRobot
+from .armrobot import ZonoArmRobot, ZonoArmRobot as ArmZonoRobot
+from .se2robot import SE2ZonoRobot
+from .se3robot import SE3ZonoRobot
+from .composablerobot import ComposedZonoRobot

--- a/zonopyrobots/robots/__init__.py
+++ b/zonopyrobots/robots/__init__.py
@@ -3,3 +3,14 @@ from .armrobot import ZonoArmRobot, ZonoArmRobot as ArmZonoRobot
 from .se2robot import SE2ZonoRobot
 from .se3robot import SE3ZonoRobot
 from .composablerobot import ComposedZonoRobot
+
+from .utils import make_urdf_fixed, make_baselink_urdf
+
+__all__ = [
+    "BaseZonoRobot",
+    "ZonoArmRobot",
+    "ArmZonoRobot",
+    "SE2ZonoRobot",
+    "SE3ZonoRobot",
+    "ComposedZonoRobot",
+]

--- a/zonopyrobots/robots/armrobot.py
+++ b/zonopyrobots/robots/armrobot.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
 from urchin import URDF, xyz_rpy_to_matrix
 import numpy as np
 import trimesh
 from typing import Union
 import torch
 import zonopy as zp
-from zonopyrobots.robots.utils import normal_vec_to_basis
+from zonopyrobots.robots.baserobot import BaseZonoRobot
+from zonopyrobots.robots.utils import normal_vec_to_basis, resolve_device_type
 import copy
 import networkx as nx
 
@@ -14,8 +18,14 @@ JOINT_INTERSECT_COUNT = 3
 INLINE_RATIO_CUTOFF = 1.5
 DEBUG_VIZ = False
 
+if TYPE_CHECKING:
+    from typing import Self
+    from torch import device as torch_device, dtype as torch_dtype
+    from numpy import dtype as np_dtype
+    from numpy.typing import ArrayLike
 
-class ZonoArmRobot:
+
+class ZonoArmRobot(BaseZonoRobot):
     """ Arm Robot definition for use with zonopy
     
     This class is a wrapper around the URDF class from urchin. It also computes
@@ -27,15 +37,6 @@ class ZonoArmRobot:
     with later forward kinematic and occupancy computations.
     
     Attributes:
-        urdf: The urchin URDF object
-        dof: The number of actuated joints
-        np: A numpy version of the object
-        tensor: A torch version of the object
-        device: The device the primary data is on. None if numpy.
-        dtype: The pytorch or numpy dtype of the class
-        origin_pos: The origin position of the robot in the world frame
-        origin_rot: The origin rotation of the robot in the world frame as a
-            3x3 rotation matrix
         joint_axis: The axis of each actuated joint in a (dof, 3) array. These
             are in topological order from the base to the end effector.
         joint_origins: The origin of each actuated joint in a topologically
@@ -66,16 +67,24 @@ class ZonoArmRobot:
         is_single_chain: True if the robot is a single kinematic chain.
         has_closed_loop: True if the robot has a closed loop in the kinematic
             chain.
+    
+    Inherited Attributes:
+        name: The name of the robot. The URDF name is used if not specified. If
+            specified, the URDF name is overwritten.
+        urdf: The urchin URDF object for the robot
+        dof: The degrees of freedom of the robot
+        np: A numpy version of the object
+        tensor: A torch version of the object
+        device: The device the primary data is on. None if numpy.
+        dtype: The pytorch or numpy dtype of the class
+        itype: The pytorch or numpy integer type of the class
+        origin_pos: The origin position of the robot in the world frame
+        origin_rot: The origin rotation of the robot in the world frame as a
+            3x3 rotation matrix
+        _basetype: The base type of the robot dtype
+        _baseitype: The base type of the robot itype
     """
     __slots__ = [
-        'urdf',
-        'dof',
-        'np',
-        'tensor',
-        'device',
-        'dtype',
-        'origin_pos',
-        'origin_rot',
         'joint_axis',
         'joint_origins',
         'joint_origins_all',
@@ -91,8 +100,6 @@ class ZonoArmRobot:
         'link_data',
         'is_single_chain',
         'has_closed_loop',
-        '__origin_pos',
-        '__origin_rot',
         '__joint_axis',
         '__joint_origins',
         '__joint_origins_all',
@@ -102,8 +109,6 @@ class ZonoArmRobot:
         '__eff_lim',
         '__continuous_joints',
         '__pos_lim_mask',
-        '__origin_pos_np',
-        '__origin_rot_np',
         '__joint_axis_np',
         '__joint_origins_np',
         '__joint_origins_all_np',
@@ -113,18 +118,112 @@ class ZonoArmRobot:
         '__eff_lim_np',
         '__continuous_joints_np',
         '__pos_lim_mask_np',
-        '__basetype'
         ]
     
-    def __init__(self):
-        pass
+    def __init__(
+            self,
+            urdf: URDF | str,
+            name: str | None = None,
+            origin_pos: ArrayLike | None = None,
+            origin_rot: ArrayLike | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+            create_joint_occupancy: bool = False,
+        ):
+        super().__init__(urdf, name, origin_pos, origin_rot, device, dtype, itype)
+
+        device_dtypes = resolve_device_type(device, dtype, itype)
+
+        # robot._G is from end effector to base
+        self.is_single_chain = nx.is_branching(self.urdf._G)
+        # Compute extra data
+        self._setup_robot_actuated_joint_data(self.urdf, device_dtypes.np_dtype, device_dtypes.np_itype)
+        self._setup_robot_joint_data(self.urdf, device_dtypes.dtype, create_joint_occupancy)
+        self._setup_robot_link_data(self.urdf, device_dtypes.dtype)
+
+        # Assign aliases
+        self.np = self.numpy()
+        self.tensor = self.to(device='cpu')
+        self.to(device=device_dtypes.device, inplace=True)
+
+    def copy(
+            self,
+            name: str | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+        ) -> Self:
+        """ Create a deep copy of the object """
+        # Call the base copy
+        ret = super().copy(name, device, dtype, itype)
+        device_dtypes = resolve_device_type(device, dtype, itype)
+
+        # Copy the additional data
+        ret.__actuated_mask_np = np.array(self.__actuated_mask_np) # bool
+        ret.__joint_axis_np = np.array(self.__joint_axis_np, dtype=device_dtypes.np_dtype)
+        ret.__joint_origins_all_np = np.array(self.__joint_origins_all_np, dtype=device_dtypes.np_dtype)
+        ret.__joint_origins_np = ret.__joint_origins_all_np[ret.__actuated_mask_np]
+        ret.__pos_lim_np = np.array(self.__pos_lim_np, dtype=device_dtypes.np_dtype).T
+        ret.__vel_lim_np = np.array(self.__vel_lim_np, dtype=device_dtypes.np_dtype)
+        ret.__eff_lim_np = np.array(self.__eff_lim_np, dtype=device_dtypes.np_dtype) # Unused for now
+        ret.__continuous_joints_np = np.array(self.__continuous_joints_np, dtype=device_dtypes.np_itype)
+        ret.__pos_lim_mask_np = np.array(self.__pos_lim_mask_np) # bool
+        ret.__actuated_mask = torch.from_numpy(ret.__actuated_mask_np)
+        ret.__joint_axis = torch.from_numpy(ret.__joint_axis_np)
+        ret.__joint_origins = torch.from_numpy(ret.__joint_origins_np)
+        ret.__joint_origins_all = torch.from_numpy(ret.__joint_origins_all_np)
+        ret.__pos_lim = torch.from_numpy(ret.__pos_lim_np)
+        ret.__vel_lim = torch.from_numpy(ret.__vel_lim_np)
+        ret.__eff_lim = torch.from_numpy(ret.__eff_lim_np)
+        ret.__continuous_joints = torch.from_numpy(ret.__continuous_joints_np)
+        ret.__pos_lim_mask = torch.from_numpy(ret.__pos_lim_mask_np)
+
+        # Recreate the joint and link data
+        ret._setup_robot_joint_data(ret.urdf, device_dtypes.dtype, False)
+        ret._setup_robot_link_data(ret.urdf, device_dtypes.dtype)
+
+        # Manually copy joint occupancy data as needed
+        if any(joint._joint_occupancy for joint in self.joint_data.values()):
+            for joint, joint_data in self.joint_data.items():
+                # get the right joint
+                ret_urdf_joint = ret.urdf._joint_map[joint.name]
+                # apply the data
+                ret_joint_data = ret.joint_data[ret_urdf_joint]
+                ret_joint_data._joint_occupancy = True
+                ret_joint_data._radius = torch.tensor(joint_data._radius_np, dtype=device_dtypes.dtype, device='cpu')
+                ret_joint_data._aabb = torch.tensor(joint_data._aabb_np, dtype=device_dtypes.dtype, device='cpu')
+                ret_joint_data._radius_np = ret_joint_data._radius.numpy()
+                ret_joint_data._aabb_np = ret_joint_data._aabb.numpy()
+                ret_joint_data._outer_pz = copy.copy(joint_data._outer_pz)
+                ret_joint_data._bounding_pz = copy.copy(joint_data._bounding_pz)
+                # update the np and tensor versions
+                ret_joint_data.np = ret_joint_data.numpy()
+                ret_joint_data.tensor = ret_joint_data.to(device='cpu')
+
+        # update aliases, create the np and tensor versions
+        ret.np = ret.numpy()
+        ret.tensor = ret.to(device='cpu')
+        ret.to(device=device_dtypes.device, inplace=True)
+        return ret
 
     @staticmethod
-    def load(robot: Union[URDF, str], device=None, dtype=None, itype=None, create_joint_occupancy=False, origin_pos=None, origin_rot=None):
+    def load(
+            robot: URDF | str,
+            name: str | None = None,
+            origin_pos: ArrayLike | None = None,
+            origin_rot: ArrayLike | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+            create_joint_occupancy: bool = False,
+        ):
         """ Load a robot from a URDF file or URDF object 
         
         Args:
             robot: The URDF file or URDF object to load
+            name: The name of the robot. The URDF name is used if not specified. If
+                specified, the URDF name is overwritten.
             device: The device to put the tensors on. None for pytorch default.
             dtype: The data type to use for the zonotopes. None for pytorch default.
             itype: The index type to use for the zonotopes. None for pytorch default.
@@ -135,39 +234,18 @@ class ZonoArmRobot:
         Returns:
             A ZonoArmRobot object
         """
-        # Resolve the dtype and device to use
-        temp_device = torch.empty(0, device=device)
-        device = temp_device.device
-        temp_dtype = torch.empty(0, device='cpu', dtype=dtype)
-        dtype = temp_dtype.dtype
-        np_dtype = temp_dtype.numpy().dtype
-        if itype is not None:
-            temp_itype = torch.empty(0, dtype=dtype, device='cpu')
-        else:
-            temp_itype = torch.tensor([0], device='cpu')
-        itype = temp_itype.dtype
-        np_itype = temp_itype.numpy().dtype
-        
-        # Prepare the robot
-        if type(robot) == str:
-            robot = URDF.load(robot)
-        constructed = ZonoArmRobot()
-        constructed.urdf = robot
-        constructed.dof = len(robot.actuated_joints)
-        # robot._G is from end effector to base
-        constructed.is_single_chain = nx.is_branching(robot._G)
-        constructed._setup_robot_actuated_joint_data(robot, origin_pos, origin_rot, np_dtype, np_itype)
-        constructed._setup_robot_joint_data(robot, dtype, create_joint_occupancy)
-        constructed._setup_robot_link_data(robot, dtype)
-        constructed.__basetype = temp_dtype
-        constructed.np = constructed.numpy()
-        constructed.tensor = constructed.to(device='cpu')
-        constructed = constructed.to(device)
-        return constructed
+        return ZonoArmRobot(
+            robot,
+            name=name,
+            origin_pos=origin_pos,
+            origin_rot=origin_rot,
+            device=device,
+            dtype=dtype,
+            itype=itype,
+            create_joint_occupancy=create_joint_occupancy,
+        )
 
-    def _setup_robot_actuated_joint_data(self, robot, origin_pos, origin_rot, np_dtype, np_itype):
-        origin_pos = np.zeros(3) if origin_pos is None else origin_pos
-        origin_rot = np.eye(3) if origin_rot is None else origin_rot
+    def _setup_robot_actuated_joint_data(self, robot, np_dtype, np_itype):
         continuous_joints = []
         pos_lim = [[-np.inf, np.inf]]*self.dof
         vel_lim = [np.inf]*self.dof
@@ -196,8 +274,6 @@ class ZonoArmRobot:
                 offset += 1
         
         # initial numpy conversion
-        self.__origin_pos_np = np.array(origin_pos, dtype=np_dtype)
-        self.__origin_rot_np = np.array(origin_rot, dtype=np_dtype)
         self.__actuated_mask_np = np.zeros(len(robot.joints), dtype=bool)
         self.__actuated_mask_np[actuated_idxs] = True
         self.__joint_axis_np = np.array(joint_axis, dtype=np_dtype)
@@ -209,13 +285,7 @@ class ZonoArmRobot:
         self.__continuous_joints_np = np.array(continuous_joints, dtype=np_itype)
         self.__pos_lim_mask_np = np.isfinite(self.__pos_lim_np).any(axis=0)
 
-        # checks
-        assert len(self.__origin_pos_np.shape) == 1 and self.__origin_pos_np.shape[0] == 3, "origin_pos must be a 3 element array"
-        assert len(self.__origin_rot_np.shape) == 2 and self.__origin_rot_np.shape[0] == 3 and self.__origin_rot_np.shape[1] == 3, "origin_rot must be a 3x3 matrix"
-
         # Create tensor references to that memory
-        self.__origin_pos = torch.from_numpy(self.__origin_pos_np)
-        self.__origin_rot = torch.from_numpy(self.__origin_rot_np)
         self.__actuated_mask = torch.from_numpy(self.__actuated_mask_np)
         self.__joint_axis = torch.from_numpy(self.__joint_axis_np)
         self.__joint_origins = torch.from_numpy(self.__joint_origins_np)
@@ -308,10 +378,8 @@ class ZonoArmRobot:
     def numpy(self):
         """ Convert and return a numpy version of the object. Does not copy data. """
         # create a shallow copy of self
-        ret = copy.copy(self)
+        ret = super().numpy()
         # update references to all the properties we care about
-        ret.origin_pos = self.__origin_pos_np
-        ret.origin_rot = self.__origin_rot_np
         ret.joint_axis = self.__joint_axis_np
         ret.joint_origins = self.__joint_origins_np
         ret.joint_origins_all = self.__joint_origins_all_np
@@ -325,19 +393,12 @@ class ZonoArmRobot:
         # update joint and link data
         ret.joint_data = {k:v.numpy() for k,v in self.joint_data.items()}
         ret.link_data = {k:v.numpy() for k,v in self.link_data.items()}
-
-        # save the device parameter
-        ret.device = None
-        ret.dtype = self.__basetype.numpy().dtype
         return ret
     
-    def to(self, device=None):
+    def to(self, device=None, inplace=False):
         """ Convert and return a torch version of the object. Does not copy data if device is the same. """
-        # create a shallow copy of self
-        ret = copy.copy(self)
+        ret = super().to(device=device, inplace=inplace)
         # update references to all the properties we care about
-        ret.origin_pos = self.__origin_pos.to(device=device)
-        ret.origin_rot = self.__origin_rot.to(device=device)
         ret.joint_axis = self.__joint_axis.to(device=device)
         ret.joint_origins = self.__joint_origins.to(device=device)
         ret.joint_origins_all = self.__joint_origins_all.to(device=device)
@@ -349,12 +410,8 @@ class ZonoArmRobot:
         ret.pos_lim_mask = self.__pos_lim_mask.to(device=device)
 
         # update joint and link data
-        ret.joint_data = {k:v.to(device=device) for k,v in self.joint_data.items()}
-        ret.link_data = {k:v.to(device=device) for k,v in self.link_data.items()}
-
-        # save the device parameter
-        ret.device = device
-        ret.dtype = self.__basetype.dtype
+        ret.joint_data = {k:v.to(device=device, inplace=inplace) for k,v in self.joint_data.items()}
+        ret.link_data = {k:v.to(device=device, inplace=inplace) for k,v in self.link_data.items()}
         return ret
 
 
@@ -429,10 +486,13 @@ class ZonoArmRobotJoint:
         ret.device = None
         return ret
 
-    def to(self, device=None):
+    def to(self, device=None, inplace=False):
         """ Convert and return a torch version of the object. Does not copy data. """
-        # create a shallow copy of self
-        ret = copy.copy(self)
+        if inplace:
+            ret = self
+        else:
+            # create a shallow copy of self
+            ret = copy.copy(self)
         # update references to all the properties we care about
         ret.axis = self._axis.to(device=device)
         ret.origin = self._origin.to(device=device)
@@ -502,10 +562,13 @@ class ZonoArmRobotLink:
         ret.device = None
         return ret
 
-    def to(self, device=None):
+    def to(self, device=None, inplace=False):
         """ Convert and return a torch version of the object. Does not copy data. """
-        # create a shallow copy of self
-        ret = copy.copy(self)
+        if inplace:
+            ret = self
+        else:
+            # create a shallow copy of self
+            ret = copy.copy(self)
         # update references to all the properties we care about
         ret.bounding_pz = self._bounding_pz.to(device=device)
         ret.mass = self._mass.to(device=device)

--- a/zonopyrobots/robots/assets/__init__.py
+++ b/zonopyrobots/robots/assets/__init__.py
@@ -1,0 +1,57 @@
+import os as _os
+from urchin import URDF as _URDF
+_basedirname = _os.path.dirname(__file__)
+
+class _Files:
+    def __init__(self):
+        raise Exception("This class is not meant to be instantiated.")
+
+    KinovaGen3 = _os.path.join(_basedirname, 'robots/kinova_arm/gen3.urdf')
+    '''URDF file for the Kinova Gen3 robot arm.'''
+
+class _Urdfs:
+    def __init__(self):
+        raise Exception("This class is not meant to be instantiated.")
+
+    @staticmethod
+    def _get_urdf_property_gen(key, file, doc=None):
+        '''Generator for a property that lazily loads a URDF object from a file.'''
+        def get_urdf_internal(cls):
+            ret = getattr(cls, f"_{key}_internal", None)
+            if ret is None:
+                ret = _URDF.load(file)
+                setattr(cls, f"_{key}_internal", ret)
+            return ret
+        
+        if doc is not None:
+            get_urdf_internal.__doc__ = doc
+        return property(get_urdf_internal)
+    
+    @classmethod
+    def register_urdf(cls, name, file, doc=None):
+        '''Registers a URDF object for a file.'''
+        setattr(_Urdfs, name, classmethod(cls._get_urdf_property_gen(name, file, doc=doc)))
+    
+    @classmethod
+    def refresh_assets(cls):
+        '''Refreshes the URDF objects for the files in the files classobject.'''
+        for key in _Files.__dict__:
+            if not key.startswith('__') and key not in _Urdfs.__dict__:
+                docstring = getattr(_Files, key).__doc__
+                file = getattr(_Files, key)
+                cls.register_urdf(
+                    key,
+                    file,
+                    doc=f"Loaded urchin URDF object from the {docstring}"
+                )
+
+_Urdfs.refresh_assets()
+'''Initializes the URDF objects for the files included. This is called automatically when the module is imported.'''
+
+files = _Files
+'''Paths to URDF files for the robots included. All paths are absolute.'''
+urdfs = _Urdfs
+'''URDF objects for the files included. All URDF objects are loaded lazily and share the same name as in files.
+If any files are added to the files object, call refresh_assets() to update them in the urdfs object.'''
+
+__all__ = ["assets", "urdfs"]

--- a/zonopyrobots/robots/assets/__init__.py
+++ b/zonopyrobots/robots/assets/__init__.py
@@ -2,15 +2,20 @@ import os as _os
 from urchin import URDF as _URDF
 _basedirname = _os.path.dirname(__file__)
 
-class _Files:
+class files:
+    '''Paths to URDF files for the robots included. All paths are absolute.'''
     def __init__(self):
+        '''This class is not meant to be instantiated.'''
         raise Exception("This class is not meant to be instantiated.")
 
     KinovaGen3 = _os.path.join(_basedirname, 'robots/kinova_arm/gen3.urdf')
     '''URDF file for the Kinova Gen3 robot arm.'''
 
-class _Urdfs:
+class urdfs:
+    '''URDF objects for the files included. All URDF objects are loaded lazily and share the same name as in :class:`files`.
+    If any files are added to the files object, call refresh_assets() to update them in the urdfs object.'''
     def __init__(self):
+        '''This class is not meant to be instantiated.'''
         raise Exception("This class is not meant to be instantiated.")
 
     @staticmethod
@@ -30,28 +35,22 @@ class _Urdfs:
     @classmethod
     def register_urdf(cls, name, file, doc=None):
         '''Registers a URDF object for a file.'''
-        setattr(_Urdfs, name, classmethod(cls._get_urdf_property_gen(name, file, doc=doc)))
+        setattr(cls, name, classmethod(cls._get_urdf_property_gen(name, file, doc=doc)))
     
     @classmethod
     def refresh_assets(cls):
         '''Refreshes the URDF objects for the files in the files classobject.'''
-        for key in _Files.__dict__:
-            if not key.startswith('__') and key not in _Urdfs.__dict__:
-                docstring = getattr(_Files, key).__doc__
-                file = getattr(_Files, key)
+        for key in files.__dict__:
+            if not key.startswith('__') and key not in files.__dict__:
+                docstring = getattr(files, key).__doc__
+                file = getattr(files, key)
                 cls.register_urdf(
                     key,
                     file,
                     doc=f"Loaded urchin URDF object from the {docstring}"
                 )
 
-_Urdfs.refresh_assets()
+urdfs.refresh_assets()
 '''Initializes the URDF objects for the files included. This is called automatically when the module is imported.'''
 
-files = _Files
-'''Paths to URDF files for the robots included. All paths are absolute.'''
-urdfs = _Urdfs
-'''URDF objects for the files included. All URDF objects are loaded lazily and share the same name as in files.
-If any files are added to the files object, call refresh_assets() to update them in the urdfs object.'''
-
-__all__ = ["assets", "urdfs"]
+# __all__ = ["assets", "urdfs"]

--- a/zonopyrobots/robots/baserobot.py
+++ b/zonopyrobots/robots/baserobot.py
@@ -21,22 +21,7 @@ class BaseZonoRobot:
     This class is meant to be subclassed and extended to provide
     the extra caching functionality useful for zonopy. It provides
     the basic structure and slots for the robot.
-    
-    Attributes:
-        name: The name of the robot. The URDF name is used if not specified. If
-            specified, the URDF name is overwritten.
-        urdf: The urchin URDF object for the robot
-        dof: The degrees of freedom of the robot
-        np: A numpy version of the object
-        tensor: A torch version of the object
-        device: The device the primary data is on. None if numpy.
-        dtype: The pytorch or numpy dtype of the class
-        itype: The pytorch or numpy integer type of the class
-        origin_pos: The origin position of the robot in the world frame
-        origin_rot: The origin rotation of the robot in the world frame as a
-            3x3 rotation matrix
-        _basetype: The base type of the robot dtype
-        _baseitype: The base type of the robot itype
+
     """
     __slots__ = [
         'urdf',
@@ -57,20 +42,49 @@ class BaseZonoRobot:
     ]
 
     urdf: URDF
+    """The urchin URDF object for the robot"""
+
     dof: int
+    """The degrees of freedom of the robot"""
+
     np: Self
+    """A numpy version of the object"""
+
     tensor: Self
+    """A CPU torch version of the object"""
+
     device: torch_device | None
+    """The device the primary data is on. None if numpy."""
+    
     dtype: torch_dtype | np_dtype
+    """The pytorch or numpy dtype of the class"""
+
     itype: torch_dtype | np_dtype
+    """The pytorch or numpy integer dtype of the class"""
+
     origin_pos: Tensor | ndarray
+    """The origin position of the robot in the world frame"""
+
     origin_rot: Tensor | ndarray
+    """The origin rotation of the robot in the world frame as a 3x3 rotation matrix"""
+
     _basetype: Tensor
+    """The base type of the robot dtype"""
+
     _baseitype: Tensor
+    """The base type of the robot itype"""
+
     __origin_pos: Tensor
+    """The underlying origin position cpu tensor reference"""
+
     __origin_rot: Tensor
+    """The underlying origin rotation cpu tensor reference"""
+
     __origin_pos_np: ndarray
+    """The underlying origin position numpy reference and data"""
+
     __origin_rot_np: ndarray
+    """The underlying origin rotation numpy reference and data"""
 
     def __init__(
             self,
@@ -82,6 +96,21 @@ class BaseZonoRobot:
             dtype: torch_dtype | np_dtype | None = None,
             itype: torch_dtype | np_dtype | None = None,
         ):
+        """ Create a new BaseZonoRobot object
+
+        Args:
+            urdf: The URDF file or URDF object to load
+            name: The name of the robot
+            origin_pos: The origin position of the robot in the world frame
+            origin_rot: The origin rotation of the robot in the world frame as a 3x3 rotation matrix
+            device: The device to put the tensors on. None for pytorch default.
+            dtype: The data type to use for the zonotopes. None for pytorch default.
+            itype: The index type to use for the zonotopes. None for pytorch default.
+        
+        Raises:
+            AssertionError: If the origin position is not a 3D vector or the origin rotation is not a 3x3 matrix
+            AssertionError: If the device is not a torch device or the dtype is not a torch or numpy dtype
+        """
 
         # Resolve the device and dtype to use
         device_dtypes = resolve_device_type(device, dtype, itype)
@@ -115,6 +144,9 @@ class BaseZonoRobot:
 
     @property
     def name(self) -> str:
+        """ The name of the robot. The URDF name is used if not specified. If
+        specified, the URDF name is overwritten.
+        """
         return self.urdf.name
 
     @name.setter
@@ -156,11 +188,24 @@ class BaseZonoRobot:
             dtype: torch_dtype | np_dtype | None = None,
             itype: torch_dtype | np_dtype | None = None,
         ) -> Self:
-        """ Create a deep copy of the robot by copying all data while respecting overlapping memory """
+        """ Create a deep copy of the robot by copying all data while respecting overlapping memory
+        
+        Args:
+            name: The name of the robot. None to keep the same name.
+            device: The device to put the tensors on. None to keep the same device.
+            dtype: The data type to use for the zonotopes. None to keep the same dtype.
+            itype: The index type to use for the zonotopes. None to keep the same itype.
+        """
         # create a shallow copy of self for the base container
         ret = copy.copy(self)
 
         # Resolve the device and dtype to use
+        if device is None:
+            device = self.device
+        if dtype is None:
+            dtype = self.dtype
+        if itype is None:
+            itype = self.itype
         device_dtypes = resolve_device_type(device, dtype, itype)
         ret._basetype = device_dtypes.basetype
         ret._baseitype = device_dtypes.baseitype
@@ -216,7 +261,11 @@ class BaseZonoRobot:
         )
 
     def numpy(self) -> Self:
-        """ Convert and return a numpy version of the object. Does not copy data. """
+        """ Convert and return a numpy version of the object. Does not copy underlying array data.
+        
+        Returns:
+            A numpy version of the object
+        """
         # create a shallow copy of self
         ret = copy.copy(self)
         # update references to the origin data
@@ -230,7 +279,15 @@ class BaseZonoRobot:
         return ret
 
     def to(self, device: torch_device = None, inplace: bool = False) -> Self:
-        """ Convert and return a torch version of the object. Does not copy data if device is the same. """
+        """ Convert and return a torch version of the object. Does not copy data if device is the same.
+        
+        Args:
+            device: The device to put the tensors on. None for pytorch default.
+            inplace: If true, update the current object in place. If false, return a new object.
+        
+        Returns:
+            A torch version of the object
+        """
         if inplace:
             ret = self
         else:

--- a/zonopyrobots/robots/baserobot.py
+++ b/zonopyrobots/robots/baserobot.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from urchin import URDF
+import copy
+import torch
+import numpy as np
+
+from zonopyrobots.robots.utils import resolve_device_type
+
+if TYPE_CHECKING:
+    from typing import Self
+    from torch import device as torch_device, dtype as torch_dtype, Tensor
+    from numpy import dtype as np_dtype, ndarray
+    from numpy.typing import ArrayLike
+
+
+class BaseZonoRobot:
+    """ Base robot definition for use with zonopy
+    
+    This class is meant to be subclassed and extended to provide
+    the extra caching functionality useful for zonopy. It provides
+    the basic structure and slots for the robot.
+    
+    Attributes:
+        name: The name of the robot. The URDF name is used if not specified. If
+            specified, the URDF name is overwritten.
+        urdf: The urchin URDF object for the robot
+        dof: The degrees of freedom of the robot
+        np: A numpy version of the object
+        tensor: A torch version of the object
+        device: The device the primary data is on. None if numpy.
+        dtype: The pytorch or numpy dtype of the class
+        itype: The pytorch or numpy integer type of the class
+        origin_pos: The origin position of the robot in the world frame
+        origin_rot: The origin rotation of the robot in the world frame as a
+            3x3 rotation matrix
+        _basetype: The base type of the robot dtype
+        _baseitype: The base type of the robot itype
+    """
+    __slots__ = [
+        'urdf',
+        'dof',
+        'np',
+        'tensor',
+        'device',
+        'dtype',
+        'itype',
+        'origin_pos',
+        'origin_rot',
+        '_basetype',
+        '_baseitype',
+        '__origin_pos',
+        '__origin_rot',
+        '__origin_pos_np',
+        '__origin_rot_np',
+    ]
+
+    urdf: URDF
+    dof: int
+    np: Self
+    tensor: Self
+    device: torch_device | None
+    dtype: torch_dtype | np_dtype
+    itype: torch_dtype | np_dtype
+    origin_pos: Tensor | ndarray
+    origin_rot: Tensor | ndarray
+    _basetype: Tensor
+    _baseitype: Tensor
+    __origin_pos: Tensor
+    __origin_rot: Tensor
+    __origin_pos_np: ndarray
+    __origin_rot_np: ndarray
+
+    def __init__(
+            self,
+            urdf: URDF | str,
+            name: str | None = None,
+            origin_pos: ArrayLike | None = None,
+            origin_rot: ArrayLike | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+        ):
+
+        # Resolve the device and dtype to use
+        device_dtypes = resolve_device_type(device, dtype, itype)
+        self._basetype = device_dtypes.basetype
+        self._baseitype = device_dtypes.baseitype
+
+        # Save the URDF and DOF
+        if type(urdf) == str:
+            robot = URDF.load(urdf)
+            if name is not None:
+                robot.name = name
+        else:
+            robot = urdf.copy(name=name)
+        self.urdf = robot
+        self.dof = int(len(self.urdf.actuated_joints))
+
+        # Save the origin position and rotation
+        origin_pos = np.zeros(3) if origin_pos is None else origin_pos
+        origin_rot = np.eye(3) if origin_rot is None else origin_rot
+        self.__origin_pos_np = np.array(origin_pos, dtype=device_dtypes.np_dtype)
+        self.__origin_rot_np = np.array(origin_rot, dtype=device_dtypes.np_dtype)
+        self.__origin_pos = torch.from_numpy(self.__origin_pos_np)
+        self.__origin_rot = torch.from_numpy(self.__origin_rot_np)
+        assert self.__origin_pos.shape == (3,), "Origin position must be a 3D vector"
+        assert self.__origin_rot.shape == (3, 3), "Origin rotation must be a 3x3 matrix"
+
+        # Create the np and tensor versions
+        self.np = BaseZonoRobot.numpy(self)
+        self.tensor = BaseZonoRobot.to(self, device='cpu')
+        BaseZonoRobot.to(self, device=device_dtypes.device, inplace=True)
+
+    @property
+    def name(self) -> str:
+        return self.urdf.name
+
+    @name.setter
+    def name(self, value: str) -> None:
+        self.urdf.name = str(value)
+    
+    def update_origin(
+            self,
+            origin_pos: ArrayLike = None,
+            origin_rot: ArrayLike = None,
+        ) -> None:
+        """ Update the origin position and rotation of the robot """
+        # update origin_pos
+        if origin_pos is not None:
+            self.__origin_pos_np = np.array(origin_pos, dtype=self._basetype.numpy().dtype)
+            self.__origin_pos = torch.from_numpy(self.__origin_pos_np)
+            assert self.__origin_pos.shape == (3,), "Origin position must be a 3D vector"
+            if self.device is not None:
+                self.origin_pos = self.__origin_pos.to(device=self.device)
+            else:    
+                self.origin_pos = self.__origin_pos_np
+        # update origin_rot
+        if origin_rot is not None:
+            self.__origin_rot_np = np.array(origin_rot, dtype=self._basetype.numpy().dtype)
+            self.__origin_rot = torch.from_numpy(self.__origin_rot_np)
+            assert self.__origin_rot.shape == (3, 3), "Origin rotation must be a 3x3 matrix"
+            if self.device is not None:
+                self.origin_rot = self.__origin_rot.to(device=self.device)
+            else:
+                self.origin_rot = self.__origin_rot_np
+        # refresh np and tensor versions
+        self.np = self.numpy()
+        self.tensor = self.to(device='cpu')
+
+    def copy(
+            self,
+            name: str | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+        ) -> Self:
+        """ Create a deep copy of the robot by copying all data while respecting overlapping memory """
+        # create a shallow copy of self for the base container
+        ret = copy.copy(self)
+
+        # Resolve the device and dtype to use
+        device_dtypes = resolve_device_type(device, dtype, itype)
+        ret._basetype = device_dtypes.basetype
+        ret._baseitype = device_dtypes.baseitype
+
+        # Copy what needs to be copied
+        ret.urdf = self.urdf.copy(name=name)
+        ret.__origin_pos_np = np.array(self.__origin_pos_np, dtype=device_dtypes.np_dtype)
+        ret.__origin_rot_np = np.array(self.__origin_rot_np, dtype=device_dtypes.np_dtype)
+        ret.__origin_pos = torch.from_numpy(ret.__origin_pos_np)
+        ret.__origin_rot = torch.from_numpy(ret.__origin_rot_np)
+
+        # Update associations
+        ret.np = BaseZonoRobot.numpy(ret)
+        ret.tensor = BaseZonoRobot.to(ret, device='cpu')
+        BaseZonoRobot.to(ret, device=device_dtypes.device, inplace=True)
+        return ret
+    
+    @staticmethod
+    def load(
+            robot: URDF | str,
+            name: str | None = None,
+            origin_pos: ArrayLike | None = None,
+            origin_rot: ArrayLike | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+        ) -> Self:
+        """ Load a robot from a URDF file or URDF object
+
+        Alias for the constructor for backwards compatibility and to allow for
+        a more consistent API with urchin.
+
+        Args:
+            robot: The URDF file or URDF object to load
+            name: The name of the robot
+            origin_pos: The origin position of the robot in the world frame
+            origin_rot: The origin rotation of the robot in the world frame as a 3x3 rotation matrix
+            device: The device to put the tensors on. None for pytorch default.
+            dtype: The data type to use for the zonotopes. None for pytorch default.
+            itype: The index type to use for the zonotopes. None for pytorch default.
+
+        Returns:
+            A BaseZonoRobot object
+        """
+        return BaseZonoRobot(
+            robot,
+            name=name,
+            origin_pos=origin_pos,
+            origin_rot=origin_rot,
+            device=device,
+            dtype=dtype,
+            itype=itype,
+        )
+
+    def numpy(self) -> Self:
+        """ Convert and return a numpy version of the object. Does not copy data. """
+        # create a shallow copy of self
+        ret = copy.copy(self)
+        # update references to the origin data
+        ret.origin_pos = self.__origin_pos_np
+        ret.origin_rot = self.__origin_rot_np
+
+        # save the device parameter
+        ret.device = None
+        ret.dtype = self._basetype.numpy().dtype
+        ret.itype = self._baseitype.numpy().dtype
+        return ret
+
+    def to(self, device: torch_device = None, inplace: bool = False) -> Self:
+        """ Convert and return a torch version of the object. Does not copy data if device is the same. """
+        if inplace:
+            ret = self
+        else:
+            # create a shallow copy of self
+            ret = copy.copy(self)
+        # update references to the origin data
+        ret.origin_pos = self.__origin_pos.to(device=device)
+        ret.origin_rot = self.__origin_rot.to(device=device)
+
+        # save the device parameter
+        ret.device = device
+        ret.dtype = self._basetype.dtype
+        ret.itype = self._baseitype.dtype
+        return ret
+
+if __name__ == '__main__':
+    import os
+    import zonopyrobots as zpr
+    basedirname = os.path.dirname(zpr.__file__)
+    a = BaseZonoRobot(URDF.load(os.path.join(basedirname, 'robots/assets/robots/kinova_arm/gen3.urdf')))
+    b = a.copy()
+    b.update_origin(origin_pos=[1, 2, 3], origin_rot=np.eye(3))
+    print("test")
+    pass

--- a/zonopyrobots/robots/baserobot.py
+++ b/zonopyrobots/robots/baserobot.py
@@ -303,6 +303,7 @@ class BaseZonoRobot:
         ret.itype = self._baseitype.dtype
         return ret
 
+
 if __name__ == '__main__':
     import os
     import zonopyrobots as zpr

--- a/zonopyrobots/robots/composablerobot.py
+++ b/zonopyrobots/robots/composablerobot.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from urchin import URDF
+import numpy as np
+import torch
+import copy
+
+from zonopyrobots.robots.baserobot import BaseZonoRobot
+from zonopyrobots.robots.utils import resolve_device_type
+
+if TYPE_CHECKING:
+    from urchin import Link
+    from typing import Self
+    from torch import device as torch_device, dtype as torch_dtype, Tensor
+    from numpy import dtype as np_dtype, ndarray
+    from numpy.typing import ArrayLike
+
+class ComposedZonoRobot(BaseZonoRobot):
+    """ A class for a robot composed of multiple zonotopic robots.
+    
+    This class is a wrapper around the URDF class from urchin, with extended functionality
+    to merge together multiple Zono-type robots. It takes in the base robot which will be
+    used as the base of the composed robot, and then additional robots which will be
+    merged together with the base robot at specific links. It also helps manage which
+    device various values are on.
+
+    Attributes:
+        base_robot: The base robot
+        robots: Dictionary of all the robots in the composed robot as {robot_object: (link_obj, link_frame)}
+        robot_map: Dictionary of robot names to robot objects
+
+    Inherited Attributes:
+        name: The name of the robot. The URDF name is used if not specified. If
+            specified, the URDF name is overwritten.
+        urdf: The urchin URDF object for the whole robot (subrobot URDF's are preserved)
+        dof: The degrees of freedom of the robot
+        np: A numpy version of the object
+        tensor: A torch version of the object
+        device: The device the primary data is on. None if numpy.
+        dtype: The pytorch or numpy dtype of the class
+        itype: The pytorch or numpy integer type of the class
+        origin_pos: The origin position of the robot in the world frame
+        origin_rot: The origin rotation of the robot in the world frame as a
+            3x3 rotation matrix
+        _basetype: The base type of the robot dtype
+        _baseitype: The base type of the robot itype
+
+    Methods:
+        add_robot: Add a robot to the composed robot
+        __getitem__: Get a robot by name
+    """
+    __slots__ = [
+        'base_robot',
+        'robots',
+        'robot_map',
+        '__robots',
+        '__robot_map',
+        '__robots_np',
+        '__robot_map_np',
+    ]
+
+    base_robot: BaseZonoRobot
+    robots: dict[BaseZonoRobot, tuple[str, ArrayLike]]
+    robot_map: dict[str, BaseZonoRobot]
+    __robots: dict[BaseZonoRobot, tuple[str, Tensor]]
+    __robot_map: dict[str, BaseZonoRobot]
+    __robots_np: dict[BaseZonoRobot, tuple[str, ndarray]]
+    __robot_map_np: dict[str, BaseZonoRobot]
+
+    def __init__(
+            self,
+            base_robot: BaseZonoRobot,
+            robots: dict[BaseZonoRobot, tuple[Link | str, ArrayLike | None] | Link | str],
+            name: str | None = None,
+            origin_pos: ArrayLike | None = None,
+            origin_rot: ArrayLike | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+        ):
+
+        # Resolve the device and types
+        device_dtypes = resolve_device_type(device, dtype, itype)
+
+        # Create the merged URDF and robots dictionary
+        self.base_robot = base_robot.copy(device=device, dtype=dtype, itype=itype)
+        combined_urdf = base_robot.urdf.copy()
+        if name is None:
+            name = base_robot.urdf.name
+        # initialize the robots dictionary with the base robot at the base link with the identity pose
+        base_origin = np.eye(4, dtype=device_dtypes.np_dtype)
+        self.__robots_np = {self.base_robot.np: (combined_urdf.base_link.name, base_origin)}
+        self.__robots = {self.base_robot.tensor: (combined_urdf.base_link.name, torch.from_numpy(base_origin))}
+        self.__robot_map_np = {self.base_robot.name: self.base_robot.np}
+        self.__robot_map = {self.base_robot.name: self.base_robot.tensor}
+        total_dof = base_robot.dof
+        # Merge the robots together
+        for rob in robots:
+            # unpack the connection data
+            link = robots[rob]
+            if isinstance(link, (tuple, list)):
+                link, link_frame = link
+            else:
+                link_frame = None
+            # get a 4x4 pose matrix from None, a 6x1 pose vector of xyzrpy, or a 4x4 pose matrix
+            from urchin.utils import configure_origin
+            link_frame = configure_origin(link_frame).astype(device_dtypes.np_dtype)
+            # resolve the link object if it's a string
+            if not isinstance(link, str):
+                link = link.name
+            # Copy robot and avoid name collisions
+            save_rob = rob.copy(device=device, dtype=dtype, itype=itype)
+            if save_rob.name in self.__robot_map:
+                i = 1
+                while f"{save_rob.name}-{i}" in self.__robot_map:
+                    i += 1
+                save_rob.name = f"{save_rob.name}-{i}"
+            # join the URDFs with a prefix for the added robot
+            prefix = f"{link}_{save_rob.name}_"
+            combined_urdf = combined_urdf.join(save_rob.urdf, link, link_frame, prefix=prefix)
+            # save the robot and connection data
+            self.__robots_np[save_rob.np] = (link, link_frame)
+            self.__robots[save_rob.tensor] = (link, torch.from_numpy(link_frame))
+            self.__robot_map_np[save_rob.name] = save_rob.np
+            self.__robot_map[save_rob.name] = save_rob.tensor
+            total_dof += rob.dof
+        combined_urdf.name = name
+
+        # Initialize the base class with the combined URDF
+        super().__init__(combined_urdf, name=name, origin_pos=origin_pos, origin_rot=origin_rot, device=device, dtype=dtype, itype=itype)
+        self.dof = total_dof
+
+        # Assign aliases
+        self.np = self.numpy()
+        self.tensor = self.to(device='cpu')
+        self.to(device=device_dtypes.device, inplace=True)
+    
+    def copy(self, name=None, device=None, dtype=None, itype=None):
+        """ Copy the robot """
+        robots_in = copy.copy(self.np.robots)
+        robots_in.pop(self.base_robot.np)
+        return ComposedZonoRobot(
+            self.base_robot,
+            robots_in,
+            name=name,
+            origin_pos=self.origin_pos,
+            origin_rot=self.origin_rot,
+            device=device,
+            dtype=dtype,
+            itype=itype,
+        )
+
+    @property
+    def name(self):
+        return self.urdf.name
+
+    @name.setter
+    def name(self, value):
+        self.urdf.name = str(value)
+    
+    @staticmethod
+    def load(
+            base_robot: BaseZonoRobot,
+            robots: dict[BaseZonoRobot, tuple[Link | str, ArrayLike | None] | Link | str],
+            name: str | None = None,
+            origin_pos: ArrayLike | None = None,
+            origin_rot: ArrayLike | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+        ):
+        return ComposedZonoRobot(
+            base_robot,
+            robots,
+            name=name,
+            origin_pos=origin_pos,
+            origin_rot=origin_rot,
+            device=device,
+            dtype=dtype,
+            itype=itype,
+        )
+    
+    def add_robot(self, robot: BaseZonoRobot, link: Link | str, link_frame: ArrayLike | None = None):
+        """ Add a robot to the composed robot """
+        # get a 4x4 pose matrix from None, a 6x1 pose vector of xyzrpy, or a 4x4 pose matrix
+        from urchin.utils import configure_origin
+        np_dtype = self._basetype.numpy().dtype
+        link_frame = configure_origin(link_frame).astype(np_dtype)
+        link_frame_tensor = torch.from_numpy(link_frame)
+        # resolve the link object if it's a string
+        if not isinstance(link, str):
+            link = link.name
+        # Copy robot and avoid name collisions
+        save_rob = robot.copy(device=self.device, dtype=self.dtype, itype=self.itype)
+        if save_rob.name in self.__robot_map:
+            i = 1
+            while f"{save_rob.name}-{i}" in self.__robot_map:
+                i += 1
+            save_rob.name = f"{save_rob.name}-{i}"
+        # join the URDFs with a prefix for the added robot
+        prefix = f"{link}_{save_rob.name}_"
+        new_urdf = self.urdf.join(save_rob.urdf, link, link_frame, prefix=prefix)
+        # save the robot and connection data
+        self.__robots_np[save_rob.np] = (link, link_frame)
+        self.__robots[save_rob.tensor] = (link, link_frame_tensor)
+        self.__robot_map_np[save_rob.name] = save_rob.np
+        self.__robot_map[save_rob.name] = save_rob.tensor
+        if self.device is not None and self.device != torch.device('cpu'):
+            self.robots[save_rob] = (link, link_frame_tensor.to(device=self.device))
+            self.robot_map[save_rob.name] = save_rob
+        # update values (because we manually update the np and tensor mapped version, update their values)
+        self.urdf = new_urdf
+        self.np.urdf = new_urdf
+        self.tensor.urdf = new_urdf
+        self.dof += robot.dof
+        self.np.dof = self.dof
+        self.tensor.dof = self.dof
+
+    def numpy(self) -> Self:
+        """ Convert the robot to numpy """
+        ret = super().numpy()
+        ret.robots = self.__robots_np
+        ret.robot_map = self.__robot_map_np
+        return ret
+    
+    def to(self, device=None, inplace=False):
+        """ Convert the robot to a specific device """
+        ret = super().to(device=device, inplace=inplace)
+        if inplace:
+            ret.robots = self.__robots
+            ret.robot_map = self.__robot_map
+            for rob_name in ret.robot_map:
+                ret.robot_map[rob_name] = ret.robot_map[rob_name].to(device=device, inplace=inplace)
+        else:
+            ret.robots = self.__robots.copy()
+            ret.robot_map = self.__robot_map.copy()
+            for rob_name in ret.robot_map:
+                mapped_robot_data = ret.robots.pop(ret.robot_map[rob_name])
+                ret.robot_map[rob_name] = ret.robot_map[rob_name].to(device=device)
+                ret.robots[ret.robot_map[rob_name]] = mapped_robot_data
+        return ret
+
+    def __getitem__(self, key: str) -> BaseZonoRobot:
+        return self.robot_map[key]
+
+if __name__ == '__main__':
+    import os
+    import zonopyrobots as zpr
+    basedirname = os.path.dirname(zpr.__file__)
+    a = zpr.ZonoArmRobot(URDF.load(os.path.join(basedirname, 'robots/assets/robots/kinova_arm/gen3.urdf')))
+    b = ComposedZonoRobot(a, {a:["base_link", [0,1,0,0,0,0]]})
+    b.add_robot(a, "base_link", [0,-1,0,0,0,0])
+    print("test")
+    pass

--- a/zonopyrobots/robots/se2robot.py
+++ b/zonopyrobots/robots/se2robot.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from numpy import dtype as np_dtype
     from numpy.typing import ArrayLike
 
+
 class SE2ZonoRobot(BaseZonoRobot):
     """ A robot with SE(2) kinematics for use with zonopy
     
@@ -23,34 +24,21 @@ class SE2ZonoRobot(BaseZonoRobot):
 
     Any FK using the SE(2) base frame will be performed with the first joint as
     the x-y position and the second joint as the rotation around the z-axis.
-    
-    Attributes:
-        fixed_urdf: The URDF with all joints set to fixed
-        original_urdf: The original URDF provided
 
-    Inherited Attributes:
-        name: The name of the robot. The URDF name is used if not specified. If
-            specified, the URDF name is overwritten.
-        urdf: The urchin URDF object for the robot
-        dof: The degrees of freedom of the robot
-        np: A numpy version of the object
-        tensor: A torch version of the object
-        device: The device the primary data is on. None if numpy.
-        dtype: The pytorch or numpy dtype of the class
-        itype: The pytorch or numpy integer type of the class
-        origin_pos: The origin position of the robot in the world frame
-        origin_rot: The origin rotation of the robot in the world frame as a
-            3x3 rotation matrix
-        _basetype: The base type of the robot dtype
-        _baseitype: The base type of the robot itype
     """
     __slots__ = [
         "fixed_urdf",
         "original_urdf",
     ]
 
+    urdf: URDF
+    """ The URDF object for the robot with the SE(2) base """
+
     fixed_urdf: URDF | None
+    """ The URDF with all joints set to fixed """
+    
     original_urdf: URDF | None
+    """ The original URDF provided """
 
     def __init__(
             self,
@@ -63,6 +51,21 @@ class SE2ZonoRobot(BaseZonoRobot):
             dtype: torch_dtype | np_dtype | None = None,
             itype: torch_dtype | np_dtype | None = None,
         ):
+        """ Create a new SE(2) robot with the provided URDF
+
+        Args:
+            urdf: The URDF file or URDF object to load and lock. If not provided,
+                a default SE(2) robot with no geometry is created.
+            name: The name of the robot. ``"se2_robot"`` is used if not specified.
+            se2_prefix: The prefix to use for the SE(2) base URDF. ``"se2_"`` is used
+                if not specified.
+            origin_pos: The origin position of the robot in the world frame
+            origin_rot: The origin rotation of the robot in the world frame as a
+                3x3 rotation matrix
+            device: The device to put the tensors on. None for pytorch default.
+            dtype: The data type to use for the zonotopes. None for pytorch default.
+            itype: The index type to use for the zonotopes. None for pytorch default.
+        """
         
         # Create a se2 base urdf programatically, then attach and lock the provided URDF
         base_urdf = _create_se2_base_urdf(name=name, prefix=se2_prefix)
@@ -109,8 +112,8 @@ class SE2ZonoRobot(BaseZonoRobot):
         Args:
             urdf: The URDF file or URDF object to load and lock. If not provided,
                 a default SE(2) robot with no geometry is created.
-            name: The name of the robot. "se2_robot" is used if not specified.
-            se2_prefix: The prefix to use for the SE(2) base URDF. "se2_" is used
+            name: The name of the robot. ``"se2_robot"`` is used if not specified.
+            se2_prefix: The prefix to use for the SE(2) base URDF. ``"se2_"`` is used
                 if not specified.
             origin_pos: The origin position of the robot in the world frame
             origin_rot: The origin rotation of the robot in the world frame as a
@@ -131,14 +134,12 @@ class SE2ZonoRobot(BaseZonoRobot):
         )
     
     def numpy(self) -> Self:
-        """ Convert the robot to a numpy version """
         ret = super().numpy()
         ret.fixed_urdf = self.fixed_urdf
         ret.original_urdf = self.original_urdf
         return ret
     
     def to(self, device: torch_device = None, inplace: bool = False) -> Self:
-        """ Convert the robot to a torch version """
         ret = super().to(device=device, inplace=inplace)
         ret.fixed_urdf = self.fixed_urdf
         ret.original_urdf = self.original_urdf
@@ -162,6 +163,7 @@ def _create_se2_base_urdf(name: str | None = None, prefix: str | None = None):
         joints = [se2_planar_joint, se2_rot_joint],
     )
     return base_urdf
+
 
 if __name__ == '__main__':
     import os

--- a/zonopyrobots/robots/se2robot.py
+++ b/zonopyrobots/robots/se2robot.py
@@ -155,7 +155,7 @@ def _create_se2_base_urdf(name: str | None = None, prefix: str | None = None):
     se2_rot = urchin.Link(f"{prefix}rot", None, [], [])
     se2_link = urchin.Link(f"{prefix}link", None, [], [])
     se2_planar_joint = urchin.Joint(f"{prefix}planar_joint", 'planar', se2_base.name, se2_rot.name)
-    se2_rot_joint = urchin.Joint(f"{prefix}rot_joint", 'continuous', se2_rot.name, se2_link.name)
+    se2_rot_joint = urchin.Joint(f"{prefix}rot_joint", 'continuous', se2_rot.name, se2_link.name, axis=[0,0,1])
     base_urdf = urchin.URDF(
         name = name,
         links = [se2_base, se2_rot, se2_link],

--- a/zonopyrobots/robots/se2robot.py
+++ b/zonopyrobots/robots/se2robot.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from urchin import URDF
+from zonopyrobots.robots.baserobot import BaseZonoRobot
+from zonopyrobots.robots.utils import make_urdf_fixed
+
+if TYPE_CHECKING:
+    from typing import Self
+    from torch import device as torch_device, dtype as torch_dtype
+    from numpy import dtype as np_dtype
+    from numpy.typing import ArrayLike
+
+class SE2ZonoRobot(BaseZonoRobot):
+    """ A robot with SE(2) kinematics for use with zonopy
+    
+    This robot is a 3 DOF robot with a planar joint and a continuous joint.
+    The planar joint is a planar joint that moves in the x-y plane.
+    The continuous joint is a continuous joint that rotates around the z-axis.
+    A URDF can be provided for geometry or collision checking, but all joints
+    will be converted to fixed joints and the robot will be placed in an SE(2)
+    base frame.
+
+    Any FK using the SE(2) base frame will be performed with the first joint as
+    the x-y position and the second joint as the rotation around the z-axis.
+    
+    Attributes:
+        fixed_urdf: The URDF with all joints set to fixed
+        original_urdf: The original URDF provided
+
+    Inherited Attributes:
+        name: The name of the robot. The URDF name is used if not specified. If
+            specified, the URDF name is overwritten.
+        urdf: The urchin URDF object for the robot
+        dof: The degrees of freedom of the robot
+        np: A numpy version of the object
+        tensor: A torch version of the object
+        device: The device the primary data is on. None if numpy.
+        dtype: The pytorch or numpy dtype of the class
+        itype: The pytorch or numpy integer type of the class
+        origin_pos: The origin position of the robot in the world frame
+        origin_rot: The origin rotation of the robot in the world frame as a
+            3x3 rotation matrix
+        _basetype: The base type of the robot dtype
+        _baseitype: The base type of the robot itype
+    """
+    __slots__ = [
+        "fixed_urdf",
+        "original_urdf",
+    ]
+
+    fixed_urdf: URDF | None
+    original_urdf: URDF | None
+
+    def __init__(
+            self,
+            urdf: URDF | str | None = None,
+            name: str | None = None,
+            se2_prefix: str | None = None,
+            origin_pos: ArrayLike | None = None,
+            origin_rot: ArrayLike | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+        ):
+        
+        # Create a se2 base urdf programatically, then attach and lock the provided URDF
+        base_urdf = _create_se2_base_urdf(name=name, prefix=se2_prefix)
+        if urdf is not None:
+            locked_urdf = make_urdf_fixed(urdf)
+            combined_urdf = base_urdf.join(locked_urdf, base_urdf.end_links[0])
+        else:
+            locked_urdf = None
+            combined_urdf = base_urdf
+
+        # Call the parent constructor
+        super().__init__(
+            urdf=combined_urdf,
+            name=name,
+            origin_pos=origin_pos,
+            origin_rot=origin_rot,
+            device=device,
+            dtype=dtype,
+            itype=itype,
+        )
+        
+        # correct the DOF and store extra URDFs
+        self.dof = 3
+        self.fixed_urdf = locked_urdf
+        self.original_urdf = urdf
+
+        # update references
+        self.np = self.numpy()
+        self.tensor = self.to(device='cpu')
+
+    @staticmethod
+    def load(
+            urdf: URDF | str | None = None,
+            name: str | None = None,
+            se2_prefix: str | None = None,
+            origin_pos: ArrayLike | None = None,
+            origin_rot: ArrayLike | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+        ):
+        """ Load a robot from a URDF file or URDF object
+
+        Args:
+            urdf: The URDF file or URDF object to load and lock. If not provided,
+                a default SE(2) robot with no geometry is created.
+            name: The name of the robot. "se2_robot" is used if not specified.
+            se2_prefix: The prefix to use for the SE(2) base URDF. "se2_" is used
+                if not specified.
+            origin_pos: The origin position of the robot in the world frame
+            origin_rot: The origin rotation of the robot in the world frame as a
+                3x3 rotation matrix
+            device: The device to put the tensors on. None for pytorch default.
+            dtype: The data type to use for the zonotopes. None for pytorch default.
+            itype: The index type to use for the zonotopes. None for pytorch default.
+        """
+        return SE2ZonoRobot(
+            urdf=urdf,
+            name=name,
+            se2_prefix=se2_prefix,
+            origin_pos=origin_pos,
+            origin_rot=origin_rot,
+            device=device,
+            dtype=dtype,
+            itype=itype,
+        )
+    
+    def numpy(self) -> Self:
+        """ Convert the robot to a numpy version """
+        ret = super().numpy()
+        ret.fixed_urdf = self.fixed_urdf
+        ret.original_urdf = self.original_urdf
+        return ret
+    
+    def to(self, device: torch_device = None, inplace: bool = False) -> Self:
+        """ Convert the robot to a torch version """
+        ret = super().to(device=device, inplace=inplace)
+        ret.fixed_urdf = self.fixed_urdf
+        ret.original_urdf = self.original_urdf
+        return ret
+
+
+def _create_se2_base_urdf(name: str | None = None, prefix: str | None = None):
+    import urchin
+    if name is None:
+        name = "se2_robot"
+    if prefix is None:
+        prefix = "se2_"
+    se2_base = urchin.Link(f"{prefix}base", None, [], [])
+    se2_rot = urchin.Link(f"{prefix}rot", None, [], [])
+    se2_link = urchin.Link(f"{prefix}link", None, [], [])
+    se2_planar_joint = urchin.Joint(f"{prefix}planar_joint", 'planar', se2_base.name, se2_rot.name)
+    se2_rot_joint = urchin.Joint(f"{prefix}rot_joint", 'continuous', se2_rot.name, se2_link.name)
+    base_urdf = urchin.URDF(
+        name = name,
+        links = [se2_base, se2_rot, se2_link],
+        joints = [se2_planar_joint, se2_rot_joint],
+    )
+    return base_urdf
+
+if __name__ == '__main__':
+    import os
+    import zonopyrobots as zpr
+    basedirname = os.path.dirname(zpr.__file__)
+    a = SE2ZonoRobot(URDF.load(os.path.join(basedirname, 'robots/assets/robots/kinova_arm/gen3.urdf')))
+    print("test")
+    pass

--- a/zonopyrobots/robots/se3robot.py
+++ b/zonopyrobots/robots/se3robot.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from urchin import URDF
+from zonopyrobots.robots.baserobot import BaseZonoRobot
+from zonopyrobots.robots.utils import make_urdf_fixed
+
+if TYPE_CHECKING:
+    from typing import Self
+    from torch import device as torch_device, dtype as torch_dtype
+    from numpy import dtype as np_dtype
+    from numpy.typing import ArrayLike
+
+class SE3ZonoRobot(BaseZonoRobot):
+    """ A robot with SE(3) kinematics for use with zonopy
+    
+    This robot is a 6 DOF robot using the floating joint type. The robot is
+    placed in an SE(3) base frame. A URDF can be provided for geometry or
+    collision checking. All joints will be converted to fixed joints.
+
+    Any FK using the SE(3) base frame will be performed with a single joint
+    with either a 6D pose vector as xyz-rpy or a 4x4 homogeneous transformation
+    matrix.
+    
+    Attributes:
+        fixed_urdf: The URDF with all joints set to fixed
+        original_urdf: The original URDF provided
+
+    Inherited Attributes:
+        name: The name of the robot. The URDF name is used if not specified. If
+            specified, the URDF name is overwritten.
+        urdf: The urchin URDF object for the robot
+        dof: The degrees of freedom of the robot
+        np: A numpy version of the object
+        tensor: A torch version of the object
+        device: The device the primary data is on. None if numpy.
+        dtype: The pytorch or numpy dtype of the class
+        itype: The pytorch or numpy integer type of the class
+        origin_pos: The origin position of the robot in the world frame
+        origin_rot: The origin rotation of the robot in the world frame as a
+            3x3 rotation matrix
+        _basetype: The base type of the robot dtype
+        _baseitype: The base type of the robot itype
+    """
+    __slots__ = [
+        "fixed_urdf",
+        "original_urdf",
+    ]
+
+    fixed_urdf: URDF | None
+    original_urdf: URDF | None
+
+    def __init__(
+            self,
+            urdf: URDF | str | None = None,
+            name: str | None = None,
+            se3_prefix: str | None = None,
+            origin_pos: ArrayLike | None = None,
+            origin_rot: ArrayLike | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+        ):
+        
+        # Create a se2 base urdf programatically, then attach and lock the provided URDF
+        base_urdf = _create_se3_base_urdf(name=name, prefix=se3_prefix)
+        if urdf is not None:
+            locked_urdf = make_urdf_fixed(urdf)
+            combined_urdf = base_urdf.join(locked_urdf, base_urdf.end_links[0])
+        else:
+            locked_urdf = None
+            combined_urdf = base_urdf
+
+        # Call the parent constructor
+        super().__init__(
+            urdf=combined_urdf,
+            name=name,
+            origin_pos=origin_pos,
+            origin_rot=origin_rot,
+            device=device,
+            dtype=dtype,
+            itype=itype,
+        )
+        
+        # correct the DOF and store extra URDFs
+        self.dof = 6
+        self.fixed_urdf = locked_urdf
+        self.original_urdf = urdf
+
+        # update references
+        self.np = self.numpy()
+        self.tensor = self.to(device='cpu')
+
+    @staticmethod
+    def load(
+            urdf: URDF | str | None = None,
+            name: str | None = None,
+            se3_prefix: str | None = None,
+            origin_pos: ArrayLike | None = None,
+            origin_rot: ArrayLike | None = None,
+            device: torch_device | None = None,
+            dtype: torch_dtype | np_dtype | None = None,
+            itype: torch_dtype | np_dtype | None = None,
+        ):
+        """ Load a robot from a URDF file or URDF object
+
+        Args:
+            urdf: The URDF file or URDF object to load and lock. If not provided,
+                a default SE(3) robot with no geometry is created.
+            name: The name of the robot. "se3_robot" is used if not specified.
+            se3_prefix: The prefix to use for the SE(2) base URDF. "se3_" is used
+                if not specified.
+            origin_pos: The origin position of the robot in the world frame
+            origin_rot: The origin rotation of the robot in the world frame as a
+                3x3 rotation matrix
+            device: The device to put the tensors on. None for pytorch default.
+            dtype: The data type to use for the zonotopes. None for pytorch default.
+            itype: The index type to use for the zonotopes. None for pytorch default.
+        """
+        return SE3ZonoRobot(
+            urdf=urdf,
+            name=name,
+            se3_prefix=se3_prefix,
+            origin_pos=origin_pos,
+            origin_rot=origin_rot,
+            device=device,
+            dtype=dtype,
+            itype=itype,
+        )
+    
+    def numpy(self) -> Self:
+        """ Convert the robot to a numpy version """
+        ret = super().numpy()
+        ret.fixed_urdf = self.fixed_urdf
+        ret.original_urdf = self.original_urdf
+        return ret
+    
+    def to(self, device: torch_device = None, inplace: bool = False) -> Self:
+        """ Convert the robot to a torch version """
+        ret = super().to(device=device, inplace=inplace)
+        ret.fixed_urdf = self.fixed_urdf
+        ret.original_urdf = self.original_urdf
+        return ret
+
+
+def _create_se3_base_urdf(name=None, prefix=None):
+    import urchin
+    if name is None:
+        name = "se3_robot"
+    if prefix is None:
+        prefix = "se3_"
+    se3_base = urchin.Link(f"{prefix}base", None, [], [])
+    se3_link = urchin.Link(f"{prefix}link", None, [], [])
+    se3_planar_joint = urchin.Joint(f"{prefix}floating_joint", 'floating', se3_base.name, se3_link.name)
+    base_urdf = urchin.URDF(
+        name = name,
+        links = [se3_base, se3_link],
+        joints = [se3_planar_joint],
+    )
+    return base_urdf
+
+if __name__ == '__main__':
+    import os
+    import zonopyrobots as zpr
+    basedirname = os.path.dirname(zpr.__file__)
+    a = SE3ZonoRobot(URDF.load(os.path.join(basedirname, 'robots/assets/robots/kinova_arm/gen3.urdf')))
+    print("test")
+    pass

--- a/zonopyrobots/robots/se3robot.py
+++ b/zonopyrobots/robots/se3robot.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from numpy import dtype as np_dtype
     from numpy.typing import ArrayLike
 
+
 class SE3ZonoRobot(BaseZonoRobot):
     """ A robot with SE(3) kinematics for use with zonopy
     
@@ -21,34 +22,21 @@ class SE3ZonoRobot(BaseZonoRobot):
     Any FK using the SE(3) base frame will be performed with a single joint
     with either a 6D pose vector as xyz-rpy or a 4x4 homogeneous transformation
     matrix.
-    
-    Attributes:
-        fixed_urdf: The URDF with all joints set to fixed
-        original_urdf: The original URDF provided
 
-    Inherited Attributes:
-        name: The name of the robot. The URDF name is used if not specified. If
-            specified, the URDF name is overwritten.
-        urdf: The urchin URDF object for the robot
-        dof: The degrees of freedom of the robot
-        np: A numpy version of the object
-        tensor: A torch version of the object
-        device: The device the primary data is on. None if numpy.
-        dtype: The pytorch or numpy dtype of the class
-        itype: The pytorch or numpy integer type of the class
-        origin_pos: The origin position of the robot in the world frame
-        origin_rot: The origin rotation of the robot in the world frame as a
-            3x3 rotation matrix
-        _basetype: The base type of the robot dtype
-        _baseitype: The base type of the robot itype
     """
     __slots__ = [
         "fixed_urdf",
         "original_urdf",
     ]
 
+    urdf: URDF
+    """ The URDF object for the robot with the SE(3) base """
+
     fixed_urdf: URDF | None
+    """ The URDF with all joints set to fixed """
+    
     original_urdf: URDF | None
+    """ The original URDF provided """
 
     def __init__(
             self,
@@ -61,8 +49,23 @@ class SE3ZonoRobot(BaseZonoRobot):
             dtype: torch_dtype | np_dtype | None = None,
             itype: torch_dtype | np_dtype | None = None,
         ):
+        """ Create a new SE(3) robot with the provided URDF
+
+        Args:
+            urdf: The URDF file or URDF object to load and lock. If not provided,
+                a default SE(3) robot with no geometry is created.
+            name: The name of the robot. ``"se3_robot"`` is used if not specified.
+            se3_prefix: The prefix to use for the SE(3) base URDF. ``"se3_"`` is used
+                if not specified.
+            origin_pos: The origin position of the robot in the world frame
+            origin_rot: The origin rotation of the robot in the world frame as a
+                3x3 rotation matrix
+            device: The device to put the tensors on. None for pytorch default.
+            dtype: The data type to use for the zonotopes. None for pytorch default.
+            itype: The index type to use for the zonotopes. None for pytorch default.
+        """
         
-        # Create a se2 base urdf programatically, then attach and lock the provided URDF
+        # Create a se3 base urdf programatically, then attach and lock the provided URDF
         base_urdf = _create_se3_base_urdf(name=name, prefix=se3_prefix)
         if urdf is not None:
             locked_urdf = make_urdf_fixed(urdf)
@@ -107,8 +110,8 @@ class SE3ZonoRobot(BaseZonoRobot):
         Args:
             urdf: The URDF file or URDF object to load and lock. If not provided,
                 a default SE(3) robot with no geometry is created.
-            name: The name of the robot. "se3_robot" is used if not specified.
-            se3_prefix: The prefix to use for the SE(2) base URDF. "se3_" is used
+            name: The name of the robot. ``"se3_robot"`` is used if not specified.
+            se3_prefix: The prefix to use for the SE(3) base URDF. ``"se3_"`` is used
                 if not specified.
             origin_pos: The origin position of the robot in the world frame
             origin_rot: The origin rotation of the robot in the world frame as a
@@ -129,14 +132,12 @@ class SE3ZonoRobot(BaseZonoRobot):
         )
     
     def numpy(self) -> Self:
-        """ Convert the robot to a numpy version """
         ret = super().numpy()
         ret.fixed_urdf = self.fixed_urdf
         ret.original_urdf = self.original_urdf
         return ret
     
     def to(self, device: torch_device = None, inplace: bool = False) -> Self:
-        """ Convert the robot to a torch version """
         ret = super().to(device=device, inplace=inplace)
         ret.fixed_urdf = self.fixed_urdf
         ret.original_urdf = self.original_urdf
@@ -158,6 +159,7 @@ def _create_se3_base_urdf(name=None, prefix=None):
         joints = [se3_planar_joint],
     )
     return base_urdf
+
 
 if __name__ == '__main__':
     import os

--- a/zonopyrobots/robots/utils.py
+++ b/zonopyrobots/robots/utils.py
@@ -15,15 +15,23 @@ def resolve_device_type(device=None, dtype=None, itype=None):
     # Resolve the dtype and device to use
     temp_device = torch.empty(0, device=device)
     device = temp_device.device
-    temp_dtype = torch.empty(0, device='cpu', dtype=dtype)
+    if isinstance(dtype, np.dtype):
+        temp_dtype = torch.from_numpy(np.empty(0, dtype=dtype))
+    else:
+        temp_dtype = torch.empty(0, device='cpu', dtype=dtype)
+        temp_dtype = torch.empty(0, device='cpu', dtype=dtype)
     dtype = temp_dtype.dtype
     np_dtype = temp_dtype.numpy().dtype
     if itype is not None:
-        temp_itype = torch.empty(0, dtype=itype, device='cpu')
+        if isinstance(itype, np.dtype):
+            temp_itype = torch.from_numpy(np.empty(0, dtype=itype))
+        else:
+            temp_itype = torch.empty(0, dtype=itype, device='cpu')
     else:
         temp_itype = torch.tensor([0], device='cpu')
     itype = temp_itype.dtype
     np_itype = temp_itype.numpy().dtype
+    assert np.issubdtype(np_itype, np.integer), "Index type must be an integer type"
     basetype = temp_dtype
     baseitype = temp_itype
     return DeviceDtype(device, dtype, np_dtype, itype, np_itype, basetype, baseitype)

--- a/zonopyrobots/robots/utils.py
+++ b/zonopyrobots/robots/utils.py
@@ -83,3 +83,18 @@ def make_urdf_fixed(urdf: URDF):
     for joint in urdf.joints:
         joint.joint_type = 'fixed'
     return urdf.copy()
+
+
+def make_baselink_urdf(name: str = None, link_name: str = None) -> URDF:
+    """ Create a URDF with a single base link """
+    import urchin
+    if name is None:
+        name = "robot"
+    if link_name is None:
+        link_name = "base_link"
+    base_link = urchin.Link(link_name, None, [], [])
+    base_urdf = urchin.URDF(
+        name = name,
+        links = [base_link],
+    )
+    return base_urdf


### PR DESCRIPTION
ZonoArmRobot is being renamed to ArmZonoRobot, but an alias remains.
Additional robot types are introduced, with various tools for manipulating and combining robots for use with zonopy.